### PR TITLE
Current npm version is broken, because of ignored lib folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules/
-lib/


### PR DESCRIPTION
Adding the lib folder to ignore list breaks the current release, npm doesn't build them on install. So that is not recommended and breaks the current version when installed via npm package manager.
Please republish. Thanks.
