### PR TITLE
Adding support for 'latest' version as allowed in npm package.json

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -22,7 +22,7 @@
           case 'gulp-pug':
           case 'jade-pug':
             cleanedVersion = this.cleanUpVersion(this.allDependencies[key]);
-            this.deprecated = compareVersion.lt(versionComparator, cleanedVersion);
+            this.deprecated = cleanedVersion == 'latest' || compareVersion.lt(versionComparator, cleanedVersion);
         }
       }
       return this.deprecated;


### PR DESCRIPTION
the current deprecation code does not support latest as a version in package.json which is valid. Adding a small check to allow it to go through