### PR TITLE
Emergent! Fix a bug where it fails with global npm modules

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -7,7 +7,10 @@ const pugParser = require('pug-parser');
 const pugWalk = require('pug-walk');
 const pugDependency = require('pug-dependency');
 
-let pkginfo = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+let pkginfo = {};
+if(fs.existsSync('./package.json')){
+  pkginfo = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+}
 
 let resolvePath = function(path, file, basedir, extension, purpose) {
 


### PR DESCRIPTION
Please merge this PR immediately.

pug-inheritance assumes that package.json always exists in working directory.

Personally I developed my original npm module which `require` gulp-pug-inheritance as dependency.
Local unit test went fine but I found that my module did not work when used as global module.

When invoking command in global npm module, it is typical that package.json does not exist in working directory.

pug-inheritance should skip reading package.json if it does not exist.

Best regards.